### PR TITLE
reset de fase dos osciladores funciona

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -105,6 +105,7 @@ class Triggers
     bool Triggered();
     bool Pressed();
     bool Released();
+    void ClearTriggered();
     bool IsBankSelectActive = false;
 };
 // Triggers


### PR DESCRIPTION
A lógica de atualização dos estados dos triggers foi modificada.

Antes, a função `UpdateAll()` do `ButtonHandler` apenas monitorava o valor cru do `RisingEdge()` para verificar se algum botão acabava de ser pressionado. Mas desta maneira, a `AudioCallback` não conseguia capturar corretamente se algum botão estava de fato sendo pressionado pela checagem `if(triggered)`.

Agora, ao invés da `UpdateAll()` apenas monitorar o valor do `RisingEdge()`, ela apenas seta o valor de `this->triggersStates[i][0] = true;`(ou seja 'acabou de ser pressionado') quando `RisingEdge()` é verdadeiro. E na `AudioCallback`, esse valor é checado e consumido, setando o valor de `this->triggersStates[i][0]` para falso.

Closes #11 